### PR TITLE
Fix navbar being overlapped by content in overview mode

### DIFF
--- a/app/styles/header/header.css
+++ b/app/styles/header/header.css
@@ -9,3 +9,8 @@
 .header .navbar {
 	margin-bottom: 0;
 }
+
+.navbar-inner {
+  position: relative;
+  z-index: 2;
+}


### PR DESCRIPTION
I made the mistake once too often of making a slide bigger than the working window. This made the navbar buttons inaccesible; probably not the desired effect.

This helps use the browser's zoom capabilities to work with huge slides.
