### PR TITLE
Fixed outline vs border style for selected elements.

### DIFF
--- a/app/styles/slide_components/ComponentView.css
+++ b/app/styles/slide_components/ComponentView.css
@@ -131,12 +131,14 @@
 }
 
 .component.selected {
-	border: 2px dashed black;
+  outline: 2px dashed black;
+  outline-offset: 1px;
 }
 
 .component.editable {
 	cursor: auto;
-	border: 2px solid red;
+  outline: 0px;
+  outline: 2px solid red;
 	-moz-user-select: text;
 	-webkit-user-select: text;
 }


### PR DESCRIPTION
Seems like some of the code of this issue #56 is missing.

In particular, I've returned outlines instead of border to avoid elements position shift when you select them. Checked it with texts, images and shapes - everything works like a charm.

P.S. I haven't found any mentions of the reason why it was reverted, so if it was by some purpose, please sorry for wasting your time.
