### PR TITLE
Element cursor is 'move', when this element is being dragged.

### DIFF
--- a/app/bundles/app/strut.slide_components/view/ComponentView.js
+++ b/app/bundles/app/strut.slide_components/view/ComponentView.js
@@ -224,6 +224,7 @@ function(Backbone, DeltaDragControl, Math2, empty, key, ComponentCommands, CmdLi
           this.dragScale = this.$el.parent().css(window.browserPrefix + "transform");
           this.dragScale = parseFloat(this.dragScale.substring(7, this.dragScale.indexOf(","))) || 1;
           this._dragging = true;
+          this.$el.addClass("dragged");
           this._prevPos = {
             x: this.model.get("x"),
             y: this.model.get("y")
@@ -316,6 +317,7 @@ function(Backbone, DeltaDragControl, Math2, empty, key, ComponentCommands, CmdLi
         var cmd;
         if (this._dragging) {
           this._dragging = false;
+          this.$el.removeClass("dragged");
           if ((this.dragStartLoc != null) && this.dragStartLoc.x !== this.model.get("x") && this.dragStartLoc.y !== this.model.get("y")) {
             cmd = new ComponentCommands.Move(this.dragStartLoc, this.model);
             undoHistory.push(cmd);

--- a/app/styles/slide_components/ComponentView.css
+++ b/app/styles/slide_components/ComponentView.css
@@ -141,6 +141,10 @@
 	-webkit-user-select: text;
 }
 
+.component.dragged:hover {
+  cursor: move;
+}
+
 .component .close-btn-red-20 {
 	display: none;
 	position: absolute;


### PR DESCRIPTION
Just a tiny improvement for elements dragging behavior:
1. Click and hold mouse on element - cursor is changed to 'move'
2. Release mouse - cursor is reverted to normal.
