### PR TITLE
Added "Clear formatting" button into text editor

### DIFF
--- a/app/bundles/app/strut.etch_extension/main.js
+++ b/app/bundles/app/strut.etch_extension/main.js
@@ -8,7 +8,8 @@ function(etch) {
             '<group>', 'justify-left', 'justify-center', '</group>',
             '<group>', 'link', '</group>',
             'font-family', 'font-size',
-            '<group>', 'color', '</group>']
+            '<group>', 'color', '</group>',
+            '<group>', 'clear-formatting', '</group>']
         });
 
     var noText = [


### PR DESCRIPTION
This is pretty useful in order to clear styles of pasted text.

This might be relevant: #152 
