### PR TITLE
Bugs with undo/redo and selection

### DIFF
--- a/app/bundles/app/strut.deck/ComponentCommands.js
+++ b/app/bundles/app/strut.deck/ComponentCommands.js
@@ -1,88 +1,101 @@
- define(function() {
-    var AddComponent, RemoveComponent;
-    AddComponent = function(slide, component) {
-      this.slide = slide;
-      this.component = component;
-    };
-    AddComponent.prototype = {
-      "do": function() {
-        return this.slide.__doAdd(this.component);
-      },
-      undo: function() {
-        return this.slide.__doRemove(this.component);
-      },
-      name: "Add Comp"
-    };
-    RemoveComponent = function(slide, component) {
-      this.slide = slide;
-      this.component = component;
-    };
-    RemoveComponent.prototype = {
-      "do": function() {
-        return this.slide.__doRemove(this.component);
-      },
-      undo: function() {
-        return this.slide.__doAdd(this.component);
-      },
-      name: "Remove Comp"
-    };
+define(function() {
 
-    function BaseCommand(initial, model, attr, name) {
-      this.start = initial;
-      this.end = model.get(attr) || 0;
-      this.model = model;
-      this.name = name;
-      this.attr = attr;
-    }
+	function BaseCommand(initial, model, attr, name) {
+		this.start = initial;
+		this.end = model.get(attr) || 0;
+		this.model = model;
+		this.name = name;
+		this.attr = attr;
+	}
 
-    BaseCommand.prototype = {
-       "do": function() {
-        this.model.set(this.attr, this.end);
-      },
-      undo: function() {
-        this.model.set(this.attr, this.start);
-      }
-    };
+	BaseCommand.prototype = {
+		"do": function() {
+			this.model.set(this.attr, this.end);
+			this.model.set('selected', true);
+		},
+		undo: function() {
+			this.model.set(this.attr, this.start);
+			this.model.set('selected', true);
+		}
+	};
 
-    Move = function(startLoc, model) {
-      this.startLoc = startLoc;
-      this.model = model;
-      this.endLoc = {
-        x: this.model.get("x"),
-        y: this.model.get("y")
-      };
-      return this;
-    };
-    Move.prototype = {
-      "do": function() {
-        return this.model.set(this.endLoc);
-      },
-      undo: function() {
-        return this.model.set(this.startLoc);
-      },
-      name: "Move"
-    };
 
-    
+	var AddComponent, RemoveComponent, MoveCommand;
 
-    return {
-      Add: AddComponent,
-      Remove: RemoveComponent,
-      Move: Move,
-      SkewX: function(initial, component) {
-        return new BaseCommand(initial, component, 'skewX', 'Skew X');
-      },
-      SkewY: function(initial, component) {
-        return new BaseCommand(initial, component, 'skewY', 'Skew Y');
-      },
-      Rotate: function(initial, component) {
-        return new BaseCommand(initial, component, 'rotate', 'Rotate');
-      },
-      Scale: function(initial, component) {
-        return new BaseCommand(initial, component, 'scale', 'Scale');
-      },
-      TextScale: function(initial, component) {
-        return new BaseCommand(initial, component, 'size', 'Scale');
-      }
-    };
-  });
+	AddComponent = function(slide, component) {
+		this.slide = slide;
+		this.component = component;
+	};
+
+	AddComponent.prototype = {
+		"do": function() {
+			this.slide.__doAdd(this.component);
+			this.component.set('selected', true);
+		},
+		undo: function() {
+			this.slide.__doRemove(this.component);
+		},
+		name: "Add Comp"
+	};
+
+
+	RemoveComponent = function(slide, component) {
+		this.slide = slide;
+		this.component = component;
+	};
+
+	RemoveComponent.prototype = {
+		"do": function() {
+			this.slide.__doRemove(this.component);
+		},
+		undo: function() {
+			this.slide.__doAdd(this.component);
+			this.slide.unselectComponents();
+			this.component.set('selected', true);
+		},
+		name: "Remove Comp"
+	};
+
+	MoveCommand = function(startLoc, model) {
+		this.startLoc = startLoc;
+		this.model = model;
+		this.endLoc = {
+			x: this.model.get("x"),
+			y: this.model.get("y")
+		};
+		return this;
+	};
+	MoveCommand.prototype = {
+		"do": function() {
+			this.model.set(this.endLoc);
+			this.model.set('selected', true);
+		},
+		undo: function() {
+			this.model.set(this.startLoc);
+			this.model.set('selected', true);
+		},
+		name: "Move"
+	};
+
+
+	return {
+		Add: AddComponent,
+		Remove: RemoveComponent,
+		Move: MoveCommand,
+		SkewX: function(initial, component) {
+			return new BaseCommand(initial, component, 'skewX', 'Skew X');
+		},
+		SkewY: function(initial, component) {
+			return new BaseCommand(initial, component, 'skewY', 'Skew Y');
+		},
+		Rotate: function(initial, component) {
+			return new BaseCommand(initial, component, 'rotate', 'Rotate');
+		},
+		Scale: function(initial, component) {
+			return new BaseCommand(initial, component, 'scale', 'Scale');
+		},
+		TextScale: function(initial, component) {
+			return new BaseCommand(initial, component, 'size', 'Scale');
+		}
+	};
+});

--- a/app/bundles/app/strut.deck/Slide.js
+++ b/app/bundles/app/strut.deck/Slide.js
@@ -120,6 +120,8 @@ function(Backbone, SpatialObject, ComponentFactory, Math2, ComponentCommands, Cm
         this.attributes.components.push(component);
         this._registerWithComponent(component);
         this.trigger("contentsChanged");
+				this.unselectComponents();
+				component.set('selected', true);
         return this.trigger("change:components.add", this, component);
       },
       /**


### PR DESCRIPTION
This pull request fixes several issues inside of ComponentsCommands.js:

**1. Elements affected by undo/redo should become selected.**
Steps to reproduce:
1. Create a text box.
2. Move it somewhere.
3. Unselect it.
4. Undo.

_Actual result:_ 
Textbox is moved back, but not selected.

_Expected result:_
Textbock is moved back AND selected.

**2. When undoing delete command, multiple elements might become selected**
Steps to reproduce:
1. Create 2 textboxes.
2. Select one of them and delete it.
3. Select second text box.
4. Undo.

_Actual result:_
Both textboxes are selected.

_Expected:_
Only first one is selected (the one which was un-removed).

**3. I've also did a little bit of refactoring inside the file:**
- Fixed indentation.
- Changed order of commands to be a little more organized.
- Explicitly defined MoveCommand variable.
