### PR TITLE
Allow overflow of slideTable so elements off the grid are still selectable

### DIFF
--- a/app/styles/transition_editor/slideTable.css
+++ b/app/styles/transition_editor/slideTable.css
@@ -5,4 +5,5 @@
 	top: 56px;
 	bottom: 0px;
 	right: 0px;
+	overflow: auto;
 }


### PR DESCRIPTION
This will make it so the contents scroll rather than the editor itself.
