### PR TITLE
Two UI niceties for the slide well

### DIFF
--- a/app/styles/slide_editor/slideWell.css
+++ b/app/styles/slide_editor/slideWell.css
@@ -6,7 +6,9 @@
 	left: 0px;
 	top: 56px;
 	bottom: 0px;
+	padding-bottom: 45px;
 	background-image: url('img/linen-gray.png');
+	z-index:2;
 }
 
 .slideWell .slideSnapshot, .slideWell .slidePlaceholder {


### PR DESCRIPTION
**Adds padding to the bottom** so the "Add Slide" button is easily accessible on mouseover when the slide being appended to is at the very bottom of the list (removes the need to scroll further to access it & generally makes it easier/nicer to use).

**Adds a z-index** so slide content doesn't obstruct the slide well. Went with the same z-index that's already being used for the navbar (figured the navbar & slide well are equally important).
