### PR TITLE
Increase z-index to coincide with slide well adding z-index

### DIFF
--- a/app/styles/header/header.css
+++ b/app/styles/header/header.css
@@ -12,7 +12,7 @@
 
 .navbar-inner {
   position: relative;
-  z-index: 2;
+  z-index: 3;
 }
 
 .row-fluid .header {


### PR DESCRIPTION
https://github.com/tantaman/Strut/pull/220 shows a need to add a z-index to the slide well, but this means the navbar-inner z-index needs to be increased so the dropdown isn't covered up.
