### PR TITLE
hide overflow on markdown thumbnails

### DIFF
--- a/app/styles/slide_components/ComponentView.css
+++ b/app/styles/slide_components/ComponentView.css
@@ -166,6 +166,7 @@
 
 .component.transitionSlideSnapshot .content {
 	outline: 0px;
+	overflow: hidden;
 }
 
 .component.editable .content {


### PR DESCRIPTION
fixes #285 