### PR TITLE
keep slide sidebar content inside slide thumbnails

### DIFF
--- a/app/styles/slide_snapshot/slideSnapshot.css
+++ b/app/styles/slide_snapshot/slideSnapshot.css
@@ -46,10 +46,6 @@
     border: 2px solid #5BB75B;
 }
 
-.slideDrawer {
-	white-space: normal;
-}
-
 .slideSnapshot > .overlay {
 	transform-origin: 0 0;
 	-webkit-transform-origin: 0 0;
@@ -58,13 +54,15 @@
 }
 
 .slideDrawer {
+	white-space: normal;
 	transform-origin: 0 0;
 	-webkit-transform-origin: 0 0;
 	-moz-transform-origin: 0 0;
 	position: relative;
 	background-size: cover;
 	background-position: center;
-  	background-repeat: no-repeat;
+	background-repeat: no-repeat;
+	overflow: hidden;
 }
 
 .slideDrawer .transformContainer {


### PR DESCRIPTION
This patch stops slide content from displaying outside the slide's thumbnail.

Before:

![screenshot from 2014-12-16 13 10 20](https://cloud.githubusercontent.com/assets/364615/5458987/eb48df70-8524-11e4-91ba-27dfe670cea9.png)

After:

![screenshot from 2014-12-16 13 11 40](https://cloud.githubusercontent.com/assets/364615/5459014/1db6125c-8525-11e4-812f-92b72723854b.png)


(it also merges two .slideDrawer CSS rules into a single rule, for cleanliness)