### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "grunt-contrib-livereload": "0.1.1",
     "grunt-usemin": "~0.1.9",
     "grunt-contrib-requirejs": "~0.4.1",
-    "grunt-mocha": "~0.2.2",
+    "grunt-mocha": "~0.4.14",
     "grunt-open": "~0.2.0",
     "matchdep": "~0.1.2",
     "grunt-text-replace": "~0.3.2"


### PR DESCRIPTION
Updated grunt-mocha version dependency to get rid of "No matching version found for phantomjs@~1.8.1" error.