### PR TITLE
docs: Fix simple typo, rquire -> require

### DIFF
--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -190,7 +190,7 @@ log.notice = function(msg) {
 		console.log(msg);
 }
 
-// reassigning rquire to r for
+// reassigning require to r for
 // the "preview" includes so they don't get built into the actual
 // amd app.
 // TODO: move this stuff into index.html


### PR DESCRIPTION
There is a small typo in app/scripts/main.js.

Should read `require` rather than `rquire`.

