### PR TITLE
coalesce, view without signing in

### DIFF
--- a/notes.md
+++ b/notes.md
@@ -8,3 +8,6 @@
   - drizzle?
 
 - force disconnect on schema update till both sides agree
+
+- test that our de-duplicating of queries works as expected. I.e., 100 components all running
+  the same query all await on a single query rather than running 100 queries.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -63,14 +63,7 @@ function ClerkProviderWithRoutes() {
           path="/sign-up/*"
           element={<SignUp routing="path" path="/sign-up" afterSignUpUrl="/" />}
         />
-        <Route
-          path="/create/:dbid/:deckid"
-          element={
-            <SignedIn>
-              <Editor />
-            </SignedIn>
-          }
-        />
+        <Route path="/create/:dbid/:deckid" element={<Editor />} />
       </Routes>
     </ClerkProvider>
   );

--- a/src/components/editor/well/WellSlide.tsx
+++ b/src/components/editor/well/WellSlide.tsx
@@ -11,6 +11,7 @@ import queries from "../../../domain/queries";
 import fns from "../../../domain/fns";
 import mutations from "../../../domain/mutations";
 import WellSlidePreview from "./WellSlidePreview";
+import { useBind } from "../../../modelHooks";
 
 const dragImageUrl = new URL(
   "../../../images/drag-slides.svg",
@@ -41,6 +42,7 @@ function WellSlide(props: {
   const previewTheme = props.appState.previewTheme;
 
   // TODO: `useBind` on `previewTheme`
+  useBind(previewTheme, ["slide_color"]);
   // useQuery(["slideColor", "font"], previewTheme);
 
   const [hideContextMenu, setHideContextMenu] = useState(false);

--- a/src/components/editor/well/WellSlide.tsx
+++ b/src/components/editor/well/WellSlide.tsx
@@ -162,7 +162,10 @@ function WellSlide(props: {
       draggable
       className={css.toClassString({
         "strt-well-slide": true,
-        selected: selectedSlides.has(props.id),
+        selected:
+          selectedSlides.size == 0
+            ? props.index == 0
+            : selectedSlides.has(props.id),
         [styles.root]: true,
         [styles.in]: dropClass === styles.in,
         [fns.getFontClass(previewTheme, theme) || ""]: true,

--- a/src/domain/queries.ts
+++ b/src/domain/queries.ts
@@ -26,13 +26,6 @@ export type Query<R, M = R[]> =
 type Result<T> = any;
 
 const queries = {
-  // TODO: we can collapse all "same calls" in the same tick. to just do 1 query
-  // e.g. if 50 components all want the same data can just collapse to 1 query.
-  // DataLoader pattern.
-  // do the data loader pattern at the db wrapper level?
-  // and/or prepared statement level?
-  // we enqueue.. we can check if anyone ahead of us in the queue is fulfilling our result.
-  // if so, we return that promise instead of enqueueing a new one.
   canUndo: (ctx: Ctx, id: IID_of<Deck>) =>
     useQuery<{ exists: number }, boolean | undefined>(
       ctx,

--- a/src/domain/queries.ts
+++ b/src/domain/queries.ts
@@ -85,8 +85,12 @@ const queries = {
   mostRecentlySelectedSlide: (ctx: Ctx, id: IID_of<Deck>) =>
     useRangeQuery<{ slide_id: IID_of<Slide> }, IID_of<Slide> | undefined>(
       ctx,
-      /*sql*/ `SELECT "slide_id" FROM "selected_slide" WHERE "deck_id" = ? ORDER BY "rowid" DESC LIMIT 1`,
-      [id],
+      /*sql*/ `SELECT 
+        coalesce(
+          (SELECT "slide_id" FROM "selected_slide" WHERE "deck_id" = ? ORDER BY "rowid" DESC LIMIT 1),
+          (SELECT "id" FROM "slide" WHERE "deck_id" = ? ORDER BY "id" ASC LIMIT 1)
+        ) as "slide_id"`,
+      [id, id],
       firstPick
     ),
 


### PR DESCRIPTION
- do not require being logged in if the user has a direct url to the presentation
- initial selection fixes when opening an existing presentation the user has no copy of