### PR TITLE
WASM extensions, step 1: compile AssemblyScript in the browser & render a component (#438)

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "check": "prettier --check ."
   },
   "dependencies": {
+    "@assemblyscript/loader": "^0.28.19",
     "@aws-sdk/client-s3": "^3.1075.0",
     "@rindle/api-server": "^0.4.3",
     "@rindle/client": "^0.4.3",
@@ -45,6 +46,7 @@
     "@tiptap/react": "^3.27.1",
     "@tiptap/starter-kit": "^3.27.1",
     "@tiptap/static-renderer": "^3.27.1",
+    "assemblyscript": "^0.28.19",
     "better-auth": "^1.6.23",
     "dompurify": "^3.4.11",
     "fractional-indexing": "^3.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@assemblyscript/loader':
+        specifier: ^0.28.19
+        version: 0.28.19
       '@aws-sdk/client-s3':
         specifier: ^3.1075.0
         version: 3.1075.0
@@ -68,6 +71,9 @@ importers:
       '@tiptap/static-renderer':
         specifier: ^3.27.1
         version: 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      assemblyscript:
+        specifier: ^0.28.19
+        version: 0.28.19
       better-auth:
         specifier: ^1.6.23
         version: 1.6.23(@prisma/client@5.22.0)(@tanstack/react-start@1.168.27(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.1.0(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)))(better-sqlite3@12.11.1)(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(solid-js@1.9.13)(vitest@4.1.9(@types/node@22.20.0)(jsdom@28.1.0(@noble/hashes@2.2.0))(vite@8.1.0(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)))
@@ -190,6 +196,9 @@ packages:
 
   '@asamuzakjp/nwsapi@2.3.9':
     resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
+
+  '@assemblyscript/loader@0.28.19':
+    resolution: {integrity: sha512-6OhPTJ0nS8aay8t2lhbA/XkyffgU15ECPsLHT0VZFG7j7sUA1CT2HS7nIALwjg6Pdpgp+RTHQukgK1IoCUbxCQ==}
 
   '@aws-crypto/crc32@5.2.0':
     resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
@@ -2285,6 +2294,11 @@ packages:
   aria-query@5.3.0:
     resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
+  assemblyscript@0.28.19:
+    resolution: {integrity: sha512-yOAlAb9EsrI00oUaf6qUTtTcYYeelG2iC3f1LnA45XUeSlMrp2O2FF5Llj4P+Y84ZiIlh/ciEEpOaPwwmOKq8g==}
+    engines: {node: '>=20', npm: '>=10'}
+    hasBin: true
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -2383,6 +2397,10 @@ packages:
 
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
+  binaryen@130.0.0-nightly.20260609:
+    resolution: {integrity: sha512-Zyl9Tw638x08LDew22YtxdYiUGxn+quzpR3ySIS4Nccv6yAiO5j1Yko9IEPNpj/aBZf71xtD/6hYXsgZ2ye3ew==}
+    hasBin: true
 
   bindings@1.5.0:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
@@ -3023,6 +3041,9 @@ packages:
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
   lru-cache@11.5.1:
     resolution: {integrity: sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==}
@@ -3857,6 +3878,8 @@ snapshots:
   '@asamuzakjp/generational-cache@1.0.1': {}
 
   '@asamuzakjp/nwsapi@2.3.9': {}
+
+  '@assemblyscript/loader@0.28.19': {}
 
   '@aws-crypto/crc32@5.2.0':
     dependencies:
@@ -5905,6 +5928,11 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
+  assemblyscript@0.28.19:
+    dependencies:
+      binaryen: 130.0.0-nightly.20260609
+      long: 5.3.2
+
   assertion-error@2.0.1: {}
 
   babel-dead-code-elimination@1.0.12:
@@ -5973,6 +6001,8 @@ snapshots:
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2
+
+  binaryen@130.0.0-nightly.20260609: {}
 
   bindings@1.5.0:
     dependencies:
@@ -6582,6 +6612,8 @@ snapshots:
       p-locate: 5.0.0
 
   lodash.merge@4.6.2: {}
+
+  long@5.3.2: {}
 
   lru-cache@11.5.1: {}
 

--- a/src/editor/ExtensionLab.tsx
+++ b/src/editor/ExtensionLab.tsx
@@ -1,0 +1,250 @@
+// Extension Lab — a DEV-ONLY harness for issue #438. It closes the loop the headless tests can't: type
+// AssemblyScript, click Run, and watch a real component appear on the active slide and persist through
+// Rindle (reload and it's still there). It is the visible end-to-end proof of Phases A–C.
+//
+// It wires the sandbox to the LIVE app: the compiled module's single capability (`strut.addText`) is
+// bound to the editor's real `mutate` and active slide, so running an extension is indistinguishable
+// from the toolbar's Add Text — same mutator, same sync, same persistence. Never mounted in production
+// (see ExtensionLabMount).
+
+import { useState } from 'react'
+import { useEditor } from './EditorState'
+import { useMutate } from '../rindle/RindleProvider'
+import { zNow } from './componentOps'
+import { compileAssemblyScript } from './asCompile'
+import { runTextExtension } from './extensionHost'
+
+// A starter extension. `render()` runs on Run; `strut.addText` is the one capability the host grants
+// (extensionHost.ts). Doubles as inline docs for the tiny surface an extension sees today.
+const STARTER = `// A trivial extension. render() runs when you click Run.
+// strut.addText is the only capability granted (see extensionHost.ts).
+@external("strut", "addText")
+declare function addText(text: string, x: f64, y: f64): void
+
+export function render(): void {
+  addText("Hello from a WASM extension", 440, 280)
+  addText("second box, stacked above", 520, 380)
+}
+`
+
+type Status =
+  | { kind: 'idle' }
+  | { kind: 'busy'; note: string }
+  | { kind: 'ok'; note: string }
+  | { kind: 'error'; note: string }
+
+export default function ExtensionLab() {
+  const editor = useEditor()
+  const mutate = useMutate()
+  const [open, setOpen] = useState(false)
+  const [source, setSource] = useState(STARTER)
+  const [status, setStatus] = useState<Status>({ kind: 'idle' })
+
+  const slideId = editor.activeSlideId
+  const canRun = editor.canEdit && !!slideId && status.kind !== 'busy'
+
+  async function run() {
+    if (!slideId) {
+      setStatus({ kind: 'error', note: 'No active slide — open a slide first.' })
+      return
+    }
+    try {
+      setStatus({ kind: 'busy', note: 'Compiling…' })
+      // exportRuntime → the loader can read strings back out of WASM memory (extensionHost).
+      const compiled = await compileAssemblyScript(source, {
+        exportRuntime: true,
+      })
+      if (!compiled.ok) {
+        setStatus({ kind: 'error', note: compiled.error })
+        return
+      }
+
+      setStatus({ kind: 'busy', note: 'Running…' })
+      const { added } = await runTextExtension(compiled.wasm, {
+        mutate,
+        slideId,
+        z_order: zNow(),
+      })
+      setStatus({
+        kind: 'ok',
+        note: `Added ${added} component${added === 1 ? '' : 's'} to the slide.`,
+      })
+    } catch (err) {
+      setStatus({
+        kind: 'error',
+        note: err instanceof Error ? err.message : String(err),
+      })
+    }
+  }
+
+  if (!open) {
+    return (
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        style={{ ...pill, top: 64, right: 12 }}
+        title="Open the extension lab (dev only)"
+      >
+        🧩 Ext Lab
+      </button>
+    )
+  }
+
+  return (
+    <div style={panel} aria-label="Extension Lab (dev)">
+      <div style={head}>
+        <strong style={{ fontSize: 12 }}>🧩 Extension Lab</strong>
+        <span style={{ fontSize: 11, opacity: 0.6 }}>dev only</span>
+        <button
+          type="button"
+          onClick={() => setOpen(false)}
+          style={iconBtn}
+          title="Close"
+        >
+          ✕
+        </button>
+      </div>
+
+      <textarea
+        value={source}
+        onChange={(e) => setSource(e.target.value)}
+        spellCheck={false}
+        style={editorArea}
+      />
+
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <button
+          type="button"
+          onClick={() => void run()}
+          disabled={!canRun}
+          style={{ ...runBtn, opacity: canRun ? 1 : 0.5 }}
+          title={
+            !editor.canEdit
+              ? 'Read-only deck'
+              : !slideId
+                ? 'No active slide'
+                : 'Compile & run'
+          }
+        >
+          {status.kind === 'busy' ? status.note : 'Compile & Run'}
+        </button>
+        {!editor.canEdit && (
+          <span style={{ fontSize: 11, opacity: 0.7 }}>read-only deck</span>
+        )}
+      </div>
+
+      {(status.kind === 'ok' || status.kind === 'error') && (
+        <pre
+          style={{
+            ...output,
+            color: status.kind === 'error' ? '#b42318' : '#067647',
+          }}
+        >
+          {status.note}
+        </pre>
+      )}
+
+      <p style={hint}>
+        Added text is a spatial component. It's directly editable only while the
+        slide is in <strong>Objects</strong> mode — in <strong>Markdown</strong>
+        mode (the default for new slides) objects render locked on top of the
+        doc. Switch the slide to Objects mode in the header to select, move, or
+        double-click-edit it.
+      </p>
+    </div>
+  )
+}
+
+// ---- inline styles (dev tool: kept self-contained, no strut.css coupling) ------------------------
+
+const pill: React.CSSProperties = {
+  position: 'fixed',
+  zIndex: 9999,
+  padding: '6px 10px',
+  borderRadius: 999,
+  border: '1px solid #d0d5dd',
+  background: '#fff',
+  boxShadow: '0 1px 4px rgba(0,0,0,.15)',
+  fontSize: 12,
+  cursor: 'pointer',
+}
+
+const panel: React.CSSProperties = {
+  position: 'fixed',
+  zIndex: 9999,
+  // Top-right, below the header: keeps clear of the TanStack devtools (bottom-left) and the
+  // "powered by rindle" credit / Overview controls (bottom-right).
+  top: 64,
+  right: 12,
+  width: 380,
+  maxWidth: 'calc(100vw - 24px)',
+  background: '#fff',
+  border: '1px solid #d0d5dd',
+  borderRadius: 10,
+  boxShadow: '0 8px 24px rgba(0,0,0,.18)',
+  padding: 10,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 8,
+  font: '13px/1.4 system-ui, sans-serif',
+  color: '#18181b',
+}
+
+const head: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 8,
+}
+
+const iconBtn: React.CSSProperties = {
+  marginLeft: 'auto',
+  border: 'none',
+  background: 'transparent',
+  cursor: 'pointer',
+  fontSize: 13,
+  color: '#667085',
+}
+
+const editorArea: React.CSSProperties = {
+  width: '100%',
+  height: 180,
+  resize: 'vertical',
+  fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+  fontSize: 12,
+  lineHeight: 1.45,
+  padding: 8,
+  border: '1px solid #e4e7ec',
+  borderRadius: 6,
+  boxSizing: 'border-box',
+}
+
+const runBtn: React.CSSProperties = {
+  padding: '6px 12px',
+  borderRadius: 6,
+  border: '1px solid #7f56d9',
+  background: '#7f56d9',
+  color: '#fff',
+  fontSize: 12,
+  fontWeight: 600,
+  cursor: 'pointer',
+}
+
+const hint: React.CSSProperties = {
+  margin: 0,
+  fontSize: 11,
+  lineHeight: 1.4,
+  color: '#667085',
+}
+
+const output: React.CSSProperties = {
+  margin: 0,
+  padding: 8,
+  background: '#f9fafb',
+  border: '1px solid #eaecf0',
+  borderRadius: 6,
+  fontSize: 11,
+  whiteSpace: 'pre-wrap',
+  wordBreak: 'break-word',
+  maxHeight: 160,
+  overflow: 'auto',
+}

--- a/src/editor/ExtensionLabMount.tsx
+++ b/src/editor/ExtensionLabMount.tsx
@@ -1,0 +1,27 @@
+// DEV-only lazy mount for the Extension Lab (issue #438). Statically importable and cheap: in a
+// production build `import.meta.env.DEV` is false, so the effect never runs and the panel module (which
+// pulls in the AssemblyScript compiler on demand) is never even fetched. Mirrors RindleDevtoolsMount in
+// src/rindle/RindleProvider.tsx.
+
+import { useEffect, useState } from 'react'
+import type { ComponentType } from 'react'
+
+export function ExtensionLabMount() {
+  const [Lab, setLab] = useState<ComponentType | null>(null)
+
+  useEffect(() => {
+    if (!import.meta.env.DEV) return
+    let live = true
+    void import('./ExtensionLab')
+      .then((m) => {
+        if (live) setLab(() => m.default)
+      })
+      .catch((e) => console.error('[ext-lab] failed to load:', e))
+    return () => {
+      live = false
+    }
+  }, [])
+
+  if (!Lab) return null
+  return <Lab />
+}

--- a/src/editor/asCompile.test.ts
+++ b/src/editor/asCompile.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import { compileAssemblyScript } from './asCompile'
+
+// Phase A of issue #438: prove the in-browser AssemblyScript → WASM compile path works and that the
+// bytes it produces are a genuine, runnable WebAssembly module. asc runs in Node, so this verifies the
+// whole thing headlessly — no browser/UI needed. (Loading + instantiating the large asc compiler makes
+// these slower than a unit test; the generous timeout keeps them from flaking on a cold cache / CI.)
+
+const TRIVIAL = `export function add(a: i32, b: i32): i32 { return a + b }`
+
+describe('compileAssemblyScript', () => {
+  it('compiles a trivial module to a non-empty WASM binary', async () => {
+    const result = await compileAssemblyScript(TRIVIAL)
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return // narrow for TS + give a useful failure above
+    // A real WASM binary starts with the magic bytes \0asm.
+    expect(result.wasm.byteLength).toBeGreaterThan(8)
+    expect(Array.from(result.wasm.slice(0, 4))).toEqual([0x00, 0x61, 0x73, 0x6d])
+  }, 30_000)
+
+  it('produces bytes that instantiate and run correctly', async () => {
+    const result = await compileAssemblyScript(TRIVIAL)
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+
+    // The strongest possible check: not just "some bytes came back" but "the module actually runs".
+    const { instance } = await WebAssembly.instantiate(result.wasm as BufferSource)
+    const add = instance.exports.add as (a: number, b: number) => number
+    expect(add(2, 3)).toBe(5)
+    expect(add(-4, 4)).toBe(0)
+  }, 30_000)
+
+  it('returns diagnostics (not a throw) for source that does not compile', async () => {
+    // `return "x"` from an i32 function is a type error asc rejects — the recoverable "author wrote bad
+    // code" path, which must surface as { ok: false, error } rather than crashing the caller.
+    const result = await compileAssemblyScript(
+      `export function bad(): i32 { return "not a number" }`,
+    )
+
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.error.length).toBeGreaterThan(0)
+  }, 30_000)
+})

--- a/src/editor/asCompile.ts
+++ b/src/editor/asCompile.ts
@@ -1,0 +1,69 @@
+// Compile an author's AssemblyScript source into a WASM binary, in the browser.
+//
+// This is the first brick of the "malleable software" work (issue #438): an LLM-authored extension is
+// written in AssemblyScript and compiled to WebAssembly so we can run it in a capability sandbox — the
+// module can only call the host functions we hand it via its import object, and can only touch its own
+// linear memory. It has no ambient access to the DOM, network or cookies.
+//
+// WHY AssemblyScript compiled HERE (client-side): the whole author → compile → run loop stays in the
+// browser (no server round-trip, unlike artifacts which upload built HTML). The `asc` compiler is large
+// (it bundles binaryen), so — exactly like the Sucrase load in artifactBuild.ts — we import it LAZILY:
+// it only lands in the chunk that actually compiles an extension, never in the base bundle a viewer pays
+// for.
+//
+// Phase A scope (this file): prove source → WASM compiles and surface diagnostics. Instantiation +
+// host-import wiring + rendering a component live in later phases.
+
+// Type-only — erased at build time, so importing from the heavy compiler here costs nothing at runtime
+// (the actual compiler is still lazily `import()`ed inside the function below).
+import type { compileString } from 'assemblyscript/asc'
+
+/** A successful compile: the raw WASM module bytes, plus the optional emitted `.wat` text (handy for
+ *  debugging / tests, null unless emitted). */
+export interface CompileOk {
+  ok: true
+  wasm: Uint8Array
+  text: string | null
+}
+
+/** A failed compile: `error` is the human-readable diagnostics (asc's stderr), e.g. a type error in the
+ *  source. This is expected, recoverable output — surface it to the author, don't throw. */
+export interface CompileErr {
+  ok: false
+  error: string
+}
+
+export type CompileResult = CompileOk | CompileErr
+
+/** asc's own compiler-options type, derived from the module so it can't drift. Optional — defaults
+ *  compile fine; callers that marshal strings/memory across the boundary pass e.g. `exportRuntime`. */
+export type AscOptions = Parameters<typeof compileString>[1]
+
+/** Compile a single AssemblyScript source string to a WASM binary.
+ *
+ *  Never throws for a *compile* failure (bad source) — those come back as `{ ok: false, error }` so the
+ *  caller can show diagnostics. It only rejects if the compiler itself fails to load (e.g. a bundling /
+ *  network problem loading the lazy chunk), which is a genuine environment error.
+ *
+ *  `asc` is dynamically imported so the compiler is code-split out of the base bundle. */
+export async function compileAssemblyScript(
+  source: string,
+  options?: AscOptions,
+): Promise<CompileResult> {
+  const asc = (await import('assemblyscript/asc')).default
+
+  // `compileString` is asc's convenience API: it parses + compiles in-memory (no virtual filesystem to
+  // wire up) and captures stdout/stderr into memory streams it returns. Defaults compile fine; callers
+  // that read strings/memory back out (via @assemblyscript/loader) pass `{ exportRuntime: true }`.
+  const result = await asc.compileString(source, options)
+
+  if (result.error || !result.binary) {
+    const diagnostics = String(result.stderr).trim()
+    return {
+      ok: false,
+      error: diagnostics || result.error?.message || 'unknown compile error',
+    }
+  }
+
+  return { ok: true, wasm: result.binary, text: result.text }
+}

--- a/src/editor/asRun.test.ts
+++ b/src/editor/asRun.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import { compileAssemblyScript } from './asCompile'
+import { instantiateWasm } from './asRun'
+
+// Phase B of issue #438: prove the JS <-> WASM boundary works in BOTH directions, driven entirely by the
+// host import object (the sandbox surface). Runs headlessly in Node — asc compiles and WebAssembly
+// instantiates there just like the browser will.
+
+async function compileOrThrow(source: string): Promise<Uint8Array> {
+  const result = await compileAssemblyScript(source)
+  if (!result.ok) throw new Error(`compile failed: ${result.error}`)
+  return result.wasm
+}
+
+describe('instantiateWasm', () => {
+  it('JS -> WASM: calls an exported function', async () => {
+    const wasm = await compileOrThrow(
+      `export function add(a: i32, b: i32): i32 { return a + b }`,
+    )
+    const { exports } = await instantiateWasm(wasm)
+    const add = exports.add as (a: number, b: number) => number
+    expect(add(2, 3)).toBe(5)
+  }, 30_000)
+
+  it('WASM -> JS: calls a host function we grant via the import object', async () => {
+    // `@external("env", "hostLog")` pins the import to env.hostLog so the namespace is deterministic —
+    // exactly how we'll pin real host capabilities later. The module can ONLY reach hostLog because we
+    // put it in the import object; that's the whole sandbox model.
+    const wasm = await compileOrThrow(`
+      @external("env", "hostLog")
+      declare function hostLog(value: i32): void
+
+      export function run(): void {
+        hostLog(42)
+        hostLog(7)
+      }
+    `)
+
+    const seen: number[] = []
+    const { exports } = await instantiateWasm(wasm, {
+      env: { hostLog: (value: number) => seen.push(value) },
+    })
+
+    expect(seen).toEqual([])
+    ;(exports.run as () => void)()
+    expect(seen).toEqual([42, 7])
+  }, 30_000)
+
+  it('does not need the caller to provide env.abort (safe defaults are supplied)', async () => {
+    // A module that can trap must still instantiate without the caller wiring up env.abort themselves.
+    const wasm = await compileOrThrow(
+      `export function ok(): i32 { assert(true); return 1 }`,
+    )
+    const { exports } = await instantiateWasm(wasm)
+    expect((exports.ok as () => number)()).toBe(1)
+  }, 30_000)
+})

--- a/src/editor/asRun.ts
+++ b/src/editor/asRun.ts
@@ -1,0 +1,61 @@
+// Instantiate a compiled AssemblyScript/WASM module and run it — the second brick of issue #438.
+//
+// THE SANDBOX IS THE IMPORT OBJECT. A WebAssembly module has no ambient authority: it can only call the
+// functions we place in its `imports` object, and can only read/write its own linear memory. It cannot
+// touch the DOM, network, cookies or globals unless we hand it a function that does. So "what an
+// extension is allowed to do" == "what host functions we pass here". Later phases grow this object
+// toward the app's mutators/queries (issue #438); every entry added is a capability granted.
+//
+// AssemblyScript emits a few standard imports its runtime may reference (`env.abort`, `env.trace`,
+// `env.seed`). We always supply safe defaults for them so instantiation never fails on a missing
+// standard import — extra imports the module doesn't declare are simply ignored by WebAssembly, so this
+// is harmless when they're unused. Caller-supplied host functions are merged on top.
+
+/** Host functions granted to the module — the capability surface. `env` is merged over our safe
+ *  defaults; any other namespace is passed through as-is. */
+export type HostImports = WebAssembly.Imports
+
+export interface WasmInstance {
+  instance: WebAssembly.Instance
+  /** The module's exported functions/memory — `instance.exports`, hoisted for convenience. */
+  exports: WebAssembly.Exports
+}
+
+/** Standard imports AssemblyScript's runtime may reference. Kept deterministic on purpose (no
+ *  Date.now/Math.random) — a sandboxed extension must not smuggle in nondeterminism through `seed`; if
+ *  we ever want controlled randomness we'll inject it explicitly, not leak the ambient clock. */
+function defaultEnv(): WebAssembly.ModuleImports {
+  return {
+    // Called when an AS `assert`/`unreachable` fires. Surface it as a JS error rather than a silent trap.
+    abort(_message: number, _fileName: number, line: number, column: number) {
+      throw new Error(`wasm aborted at ${line}:${column}`)
+    },
+    // AS `trace(...)` debug hook — no-op by default.
+    trace(_message: number, _n: number) {},
+    // Seeds AS's Math.random. Fixed value → deterministic sandbox.
+    seed() {
+      return 0
+    },
+  }
+}
+
+/** Instantiate a WASM binary with a controlled host import object.
+ *
+ *  `hostImports.env` is layered ON TOP of the safe defaults (so a caller can override `trace`, or add
+ *  its own `env` host functions, without losing `abort`). Rejects only if the bytes aren't a valid
+ *  module or a *declared* import is missing. */
+export async function instantiateWasm(
+  wasm: Uint8Array,
+  hostImports: HostImports = {},
+): Promise<WasmInstance> {
+  const imports: WebAssembly.Imports = {
+    ...hostImports,
+    // `...undefined` is a safe no-op, so this also covers a caller that passes no `env` namespace.
+    env: { ...defaultEnv(), ...hostImports.env },
+  }
+  const { instance } = await WebAssembly.instantiate(
+    wasm as BufferSource,
+    imports,
+  )
+  return { instance, exports: instance.exports }
+}

--- a/src/editor/extensionHost.test.ts
+++ b/src/editor/extensionHost.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest'
+import type { AddTextArgs } from '../../shared/app-def'
+import { DEFAULT_FONT_SIZE } from '../config'
+import { compileAssemblyScript } from './asCompile'
+import { runTextExtension } from './extensionHost'
+
+// Phase C of issue #438: the full end-to-end path, headless. An extension written in AssemblyScript
+// declares the `strut.addText` capability and calls it; we compile it, run it, and assert the host
+// turned each call into a correct `addText` mutator invocation — including a real STRING marshaled out
+// of WASM linear memory. The only thing not exercised here is the React render + Rindle persist, which
+// need the running app (Phase D wires that up).
+
+// An extension: adds two text components when run. `@external("strut", "addText")` pins the import so
+// the module reaches exactly the capability we grant, under a deterministic name.
+const EXTENSION_SOURCE = `
+  @external("strut", "addText")
+  declare function addText(text: string, x: f64, y: f64): void
+
+  export function render(): void {
+    addText("Hello from WASM", 100, 200)
+    addText("second box", 300, 400)
+  }
+`
+
+async function compileExtension(source: string): Promise<Uint8Array> {
+  // exportRuntime → the loader can read strings back out of linear memory (__getString).
+  const result = await compileAssemblyScript(source, { exportRuntime: true })
+  if (!result.ok) throw new Error(`compile failed: ${result.error}`)
+  return result.wasm
+}
+
+describe('runTextExtension', () => {
+  it('turns each WASM addText call into a correct mutator call, with the string marshaled', async () => {
+    const wasm = await compileExtension(EXTENSION_SOURCE)
+
+    const calls: AddTextArgs[] = []
+    const result = await runTextExtension(wasm, {
+      mutate: { addText: (a) => calls.push(a) },
+      slideId: 'slide-1',
+    })
+
+    expect(result.added).toBe(2)
+    expect(calls).toHaveLength(2)
+
+    // The string survived the trip through linear memory.
+    expect(calls[0].text).toBe('Hello from WASM')
+    expect(calls[1].text).toBe('second box')
+
+    // Coordinates passed straight through.
+    expect(calls[0].x).toBe(100)
+    expect(calls[0].y).toBe(200)
+    expect(calls[1].x).toBe(300)
+
+    // z-order increments so the two boxes stack in call order.
+    expect(calls[0].z_order).toBe(0)
+    expect(calls[1].z_order).toBe(1)
+
+    // Host-supplied invariants: bound to the target slide, ids minted host-side (not by the sandbox),
+    // and the same theme-inheriting defaults a toolbar insert uses.
+    expect(calls[0].slideId).toBe('slide-1')
+    expect(calls[0].id).toBeTruthy()
+    expect(calls[1].id).toBeTruthy()
+    expect(calls[0].id).not.toBe(calls[1].id)
+    expect(calls[0].size).toBe(DEFAULT_FONT_SIZE)
+    expect(calls[0].color).toBe('')
+    expect(calls[0].font_family).toBe('')
+    expect(calls[0].text_type).toBe('body')
+  }, 30_000)
+
+  it('honors a custom starting z-order', async () => {
+    const wasm = await compileExtension(EXTENSION_SOURCE)
+    const calls: AddTextArgs[] = []
+    await runTextExtension(wasm, {
+      mutate: { addText: (a) => calls.push(a) },
+      slideId: 's',
+      z_order: 10,
+    })
+    expect(calls.map((c) => c.z_order)).toEqual([10, 11])
+  }, 30_000)
+
+  it('does nothing (no throw) when the module has no render entry', async () => {
+    const wasm = await compileExtension(
+      `export function noop(): void {}`,
+    )
+    const calls: AddTextArgs[] = []
+    const result = await runTextExtension(wasm, {
+      mutate: { addText: (a) => calls.push(a) },
+      slideId: 's',
+    })
+    expect(result.added).toBe(0)
+    expect(calls).toHaveLength(0)
+  }, 30_000)
+})

--- a/src/editor/extensionHost.ts
+++ b/src/editor/extensionHost.ts
@@ -1,0 +1,91 @@
+// Run a compiled extension and grant it ONE real capability: add text to the current slide.
+//
+// This is the third brick of issue #438 and the first time a sandboxed WASM module reaches into the
+// real app. The capability is the host import object (see asRun.ts): here it holds a single function,
+// `strut.addText`, which the extension calls. That function is the seam where the maximally-restricted
+// WASM world meets Strut's write API — it turns a call from inside the sandbox into the exact same
+// `mutate.addText(...)` an editor button fires (Header.tsx). Growing this object toward the full mutator
+// / query surface (issue #438) is how the extension's powers grow — one entry = one capability.
+//
+// String marshaling: AssemblyScript strings live as UTF-16 in the module's linear memory, so a string
+// argument arrives at the host as a POINTER (a number). We use @assemblyscript/loader's `__getString`
+// to read the actual text out of that memory. The module is compiled with `exportRuntime` so the loader
+// can do this.
+
+import { instantiate as loaderInstantiate } from '@assemblyscript/loader'
+import type { AddTextArgs } from '../../shared/app-def'
+import { DEFAULT_FONT_SIZE, newId } from '../config'
+
+/** The slice of the live `mutate` facade an extension needs. Structural so the real facade (which has
+ *  every mutator) stays assignable — and so tests can pass a fake. */
+export interface ExtensionMutate {
+  addText: (a: AddTextArgs) => unknown
+}
+
+export interface RunExtensionDeps {
+  /** The write API the extension's capabilities call into (the real `mutate`, or a fake in tests). */
+  mutate: ExtensionMutate
+  /** The slide new components land on (the editor's active slide). */
+  slideId: string
+  /** Starting z-order; each added component takes the next value so they stack in call order. */
+  z_order?: number
+  /** The exported function to run. Extensions expose `render()` by convention. */
+  entry?: string
+}
+
+export interface RunExtensionResult {
+  /** How many components the extension added — handy for tests and a future "did it do anything?" hint. */
+  added: number
+}
+
+/** The exports we care about: the loader's helpers (`__getString`) plus the extension's entry point. */
+type ExtensionExports = { render?: () => void }
+
+/** Instantiate a compiled extension with the `strut.addText` capability and run its entry point.
+ *
+ *  Every `addText` the module calls becomes a real `mutate.addText(...)` on `slideId`, with the same
+ *  defaults an editor insert uses (theme-inherited color/font, body text). Deterministic ids come from
+ *  `newId()` on the host side — never from the sandbox — so the extension can't forge or collide ids. */
+export async function runTextExtension(
+  wasm: Uint8Array,
+  deps: RunExtensionDeps,
+): Promise<RunExtensionResult> {
+  // Set after instantiation; the host fn below only runs once the module is calling us, by which point
+  // the loader helpers exist.
+  let readString: ((ptr: number) => string) | null = null
+  let z = deps.z_order ?? 0
+  let added = 0
+
+  const imports = {
+    strut: {
+      // The extension's view: `declare function addText(text: string, x: f64, y: f64): void`.
+      // AS passes the string as a memory pointer; we read it back with the loader.
+      addText(textPtr: number, x: number, y: number): void {
+        const text = readString ? readString(textPtr) : ''
+        deps.mutate.addText({
+          id: newId(),
+          slideId: deps.slideId,
+          x,
+          y,
+          z_order: z++,
+          text,
+          size: DEFAULT_FONT_SIZE,
+          // '' = inherit the deck theme's body defaults, exactly like the toolbar's Add Text.
+          color: '',
+          font_family: '',
+          text_type: 'body',
+        })
+        added++
+      },
+    },
+  }
+
+  const { exports } = await loaderInstantiate<ExtensionExports>(wasm, imports)
+  readString = exports.__getString
+
+  const entryName = deps.entry ?? 'render'
+  const entry = (exports as Record<string, unknown>)[entryName]
+  if (typeof entry === 'function') (entry as () => void)()
+
+  return { added }
+}

--- a/src/routes/deck.$deckId.tsx
+++ b/src/routes/deck.$deckId.tsx
@@ -12,6 +12,7 @@ import { Stage } from '../editor/Stage'
 import { Overview } from '../editor/Overview'
 import { ResearchView } from '../editor/ResearchView'
 import { ChatPanel } from '../editor/ChatPanel'
+import { ExtensionLabMount } from '../editor/ExtensionLabMount'
 import { PoweredByRindle } from '../editor/PoweredByRindle'
 import { MobileTabBar } from '../editor/mobile/MobileTabBar'
 import type { DeckRoot, SlideDetail } from '../editor/deckDetail'
@@ -151,6 +152,8 @@ function EditorInner({ deckId }: { deckId: string }) {
           controls in the same bottom-right corner, so we'd collide there. (Hidden on mobile, where
           the bottom tab bar owns that corner — see strut.css.) */}
       {editor.mode === 'slide' && <PoweredByRindle />}
+      {/* DEV-only: AssemblyScript → WASM extension harness (issue #438). No-ops in production. */}
+      <ExtensionLabMount />
       {/* Bottom tab bar — hidden above the mobile breakpoint (strut.css); on phones it owns mode +
           Advisor + Present, which the header sheds there. Last child so sheets anchor above it. */}
       <MobileTabBar


### PR DESCRIPTION
First step toward the "malleable software" idea from #438. This proves the risky unknown end-to-end: an extension written in AssemblyScript, compiled to WASM **in the browser**, running in a capability sandbox, and rendering a real component on a slide through the normal `addText` mutator (so it syncs + persists through Rindle like any other edit).

Scoped deliberately small so it's easy to review — this is the "get it compiling and render one component, then build out from there" milestone, not the whole system.

## Demo

<img width="1516" height="866" alt="strut_rec" src="https://github.com/user-attachments/assets/759a768f-0413-442a-b738-70101ec67b74" />

The clip shows an extension running, a text box appearing on the slide, and Rindle's devtools capturing the `addText()` mutation going over the wire.

## What's in here

Four small layers, each independently tested:

1. **`asCompile.ts`** — `compileAssemblyScript(source)` lazily loads the `asc` compiler (same trick as the Sucrase load in `artifactBuild.ts`, so viewers never pay for it) and returns `{ ok, wasm }` or `{ ok: false, error }`. Compile errors are data, not throws.
2. **`asRun.ts`** — `instantiateWasm(wasm, hostImports)`. The import object *is* the sandbox: a module has zero ambient authority and can only call the host functions we hand it. Safe defaults for AS's `abort`/`trace`/`seed` (kept deterministic — no `Date.now`/`Math.random` leaking in).
3. **`extensionHost.ts`** — `runTextExtension(...)` grants exactly one capability, `strut.addText`, wired to the live `mutate`. Strings are marshaled out of WASM linear memory via `@assemblyscript/loader`. IDs are minted host-side (the sandbox can't forge/collide them) and the component is always bound to the host-chosen slide.
4. **`ExtensionLab.tsx` / `ExtensionLabMount.tsx`** — a **dev-only** harness (textarea + Compile & Run) wired to the active slide. Gated behind `import.meta.env.DEV` and lazy-loaded, so it's never in a production build. This is purely for demoing/iterating — happy to drop or relocate it if you'd prefer the spike as tests-only.

## Why AssemblyScript + the import-object sandbox

WASM can't touch the DOM, network, or cookies unless we import a function that does — so "what an extension may do" == "what's in the import object." Today that's a single entry (`addText`); growing it toward the mutators/queries surface you mentioned is how the capability set grows, one function at a time.

## Tests

9 headless tests (Vitest, `asc` runs in Node):
- compile a trivial module -> valid WASM (magic bytes) that actually instantiates and runs
- JS -> WASM (call an export) and WASM -> JS (module calls a granted host fn)
- full path: an extension calls `addText("...")` -> correct mutator args, string marshaled, z-order/ids/defaults right
- bad source returns diagnostics instead of crashing

## Not in scope yet (the "grow from there")

- EAV tables for extension-persisted state
- exposing the full mutator/query surface (only `addText` today)
- letting the LLM author the source (harness uses hand-written AS for now)

## Notes for reviewers

- New deps: `assemblyscript` + `@assemblyscript/loader`. The compiler is heavy but lazy-loaded, so it stays out of the base bundle.
- Heads up on one bit of expected behavior: added text is a spatial component, so it's only directly editable while the slide is in **Objects** mode — in Markdown mode (the default) spatial objects render locked. The Lab shows a hint about this.
- No Rindle friction to report — the isomorphic-mutator model made the host binding straightforward.
