### PR TITLE
Persist per-deck editor prefs via a local-only table

### DIFF
--- a/src/rindle/client.ts
+++ b/src/rindle/client.ts
@@ -78,6 +78,12 @@ async function create() {
     // writes under. The API server derives the SAME id from the session cookie for the authoritative
     // run (server/session.ts), so the prediction matches (no snap-back).
     user: () => sessionUserId,
+    // Durable local tables: persist every `local: true` table (`deck_pref`) to IndexedDB, keyed per
+    // (origin, user), and keep it coherent across this device's tabs. `ensureSession()` above already
+    // resolved `sessionUserId`, so it's the stable storage identity for this client's lifetime (an
+    // anonymous guest gets the 'anon' sentinel until it promotes). `chat_message` opts out via
+    // `local: "session"` (localSchema.ts), so the advisor thread stays ephemeral even with this on.
+    persistLocal: { user: sessionUserId || 'anon' },
     api: {
       // NOTE: request url = api.url + routes.query, and routes.query defaults to the ABSOLUTE
       // "/api/rindle/query". The app basepath is the only safe prefix here: root builds use "",

--- a/src/rindle/deckPref.ts
+++ b/src/rindle/deckPref.ts
@@ -1,0 +1,59 @@
+// Per-deck editor preferences, persisted on THIS device via the `deck_pref` local-only table
+// (localSchema.ts). Today that's just `chat_open` — whether the ✨ Chat panel was open — so reopening a
+// deck lands you where you left it instead of always closed.
+//
+// The read is a live materialized view over the local table (the same shape as the ✨ Chat thread's own
+// read in aiChat.ts). The write is a `store.writeLocal` UPSERT: the store-level tx exposes add/edit/remove
+// (not a keyed upsert), so we `edit` the existing row or `add` the first one. `persistLocal` (client.ts)
+// makes that row durable + cross-tab; nothing here has to know it's persisted — locality is a schema fact.
+
+import { useCallback, useEffect, useMemo, useSyncExternalStore } from 'react'
+import { useStore } from './RindleProvider'
+import type { DeckPrefRow } from './localSchema.ts'
+
+const EMPTY: readonly DeckPrefRow[] = []
+
+type SetChatOpen = (next: boolean | ((open: boolean) => boolean)) => void
+
+/** `[chatOpen, setChatOpen]` for a deck, backed by the persisted `deck_pref` local table. Before the
+ *  browser store boots (SSR / first paint) the pref reads `false` and the setter no-ops — the panel just
+ *  starts closed, then opens on its own if this device left it open. */
+export function useDeckChatOpen(deckId: string): [boolean, SetChatOpen] {
+  const store = useStore()
+
+  // One live view per (store, deckId): 0 or 1 row, since deck_id is the pk. Torn down on change / unmount.
+  const view = useMemo(
+    () =>
+      store ? store.query.deck_pref.where.deck_id(deckId).materialize() : null,
+    [store, deckId],
+  )
+  useEffect(() => () => view?.destroy(), [view])
+
+  const subscribe = useCallback(
+    (onChange: () => void) =>
+      view ? view.subscribe(() => onChange()) : () => {},
+    [view],
+  )
+  const getSnapshot = useCallback(
+    (): readonly DeckPrefRow[] => (view ? view.data : EMPTY),
+    [view],
+  )
+  const rows = useSyncExternalStore(subscribe, getSnapshot, () => EMPTY)
+  const current = rows[0]
+  const chatOpen = current?.chat_open ?? false
+
+  const setChatOpen = useCallback<SetChatOpen>(
+    (next) => {
+      if (!store) return // pre-boot: the toggle isn't reachable before the editor store lands
+      const value = typeof next === 'function' ? next(chatOpen) : next
+      if (value === chatOpen) return
+      void store.writeLocal((tx) => {
+        if (current) tx.edit('deck_pref', current, { ...current, chat_open: value })
+        else tx.add('deck_pref', { deck_id: deckId, chat_open: value })
+      })
+    },
+    [store, deckId, current, chatOpen],
+  )
+
+  return [chatOpen, setChatOpen]
+}

--- a/src/rindle/localSchema.ts
+++ b/src/rindle/localSchema.ts
@@ -1,18 +1,40 @@
-// The client-only Rindle schema extension: a memory-only `chat_message` table for the "✨ Chat" advisor
-// panel. This is the canonical local-table use case — private, per-device scratch text
-// that never syncs.
+// The client-only Rindle schema extension: two local-only tables the browser engine adds on top of the
+// synced `schema`. Neither ever syncs (invisible to co-editors), both are written with `store.writeLocal`
+// (NOT `app.mutate.*` — a replayable shared mutator may not touch a local table) and read with
+// `store.query.*` (a named/remote query may not reference a local table by design). Only the BROWSER
+// client learns them (see client.ts `clientSchema`); SSR / the server keep the plain synced `schema`.
 //
-// `{ local: true }` makes the table client-authoritative and memory-only: it NEVER syncs (invisible to
-// co-editors), is written with `store.writeLocal` (NOT `app.mutate.*` — a replayable shared mutator may
-// not touch a local table), read with `store.query.chat_message` (a named/remote query may not reference a
-// local table by design), and is gone on reload. That's deliberate: an advisor bounce doesn't need durable
-// history. Only the BROWSER client learns this table (see client.ts `clientSchema`); SSR / the server keep
-// the plain synced `schema`, which is correct — the table simply doesn't exist server-side.
+// The two variants of `local` differ ONLY in durability (client.ts enables `persistLocal`, so the split
+// is now live):
+//   • `local: true`     → DURABLE + cross-tab: persisted per (origin, user) in IndexedDB and kept
+//                         coherent across this device's tabs. Use it for device preferences that should
+//                         survive a reload. → `deck_pref`.
+//   • `local: "session"` → EPHEMERAL, per-tab: never persisted, never replicated across tabs, gone on
+//                         reload — even with `persistLocal` on. Use it for scratch state. → `chat_message`.
 
-import { extendSchema, number, string, table } from '@rindle/client'
+import { boolean, extendSchema, number, string, table } from '@rindle/client'
 import { schema } from '../../shared/app-def.ts'
 
-export const chatMessage = table('chat_message', { local: true })
+// Per-deck editor preferences for THIS device, persisted across reloads (`local: true`). Keyed by deck,
+// so reopening a deck restores how you left it — currently just whether the ✨ Chat panel was open.
+// Never synced: it's a device preference, not deck content (no cross-store FK to `deck` — a plain string).
+export const deckPref = table('deck_pref', { local: true })
+  .columns({
+    deck_id: string(),
+    chat_open: boolean(), // was the ✨ Chat panel open when you last left this deck?
+  })
+  .primaryKey('deck_id')
+
+/** A `deck_pref` row (all columns), for the `store.writeLocal` upsert (`tx.edit` wants the full prior row). */
+export interface DeckPrefRow {
+  deck_id: string
+  chat_open: boolean
+}
+
+// The "✨ Chat" advisor thread. EPHEMERAL by choice (`local: "session"`): an advisor bounce doesn't need
+// durable history, and it must NOT follow the user across tabs — so it stays outside the persistence plane
+// even though `persistLocal` is on. Written with `store.writeLocal`, read with `store.query.chat_message`.
+export const chatMessage = table('chat_message', { local: 'session' })
   .columns({
     id: string(),
     deck_id: string(), // scopes the thread to a deck (a plain string — no cross-store FK to `deck`)
@@ -36,7 +58,9 @@ export interface ChatMessageRow {
   created: number
 }
 
-// extendSchema deliberately accepts ONLY { local: true } tables — synced tables stay server-generated
-// (`rindle schema gen`) so client and server can't drift. The browser client is built with this combined
-// schema; everything downstream (`store.query.chat_message`, `store.writeLocal`) then resolves typed.
-export const clientSchema = extendSchema(schema, { tables: [chatMessage] })
+// extendSchema deliberately accepts ONLY local tables (`local: true` / `"session"`) — synced tables stay
+// server-generated (`rindle schema gen`) so client and server can't drift. The browser client is built
+// with this combined schema; everything downstream (`store.query.*`, `store.writeLocal`) then resolves typed.
+export const clientSchema = extendSchema(schema, {
+  tables: [deckPref, chatMessage],
+})

--- a/src/routes/deck.$deckId.tsx
+++ b/src/routes/deck.$deckId.tsx
@@ -9,6 +9,7 @@ import {
 } from '../../shared/queries'
 import { authClient } from '../rindle/authClient'
 import { preloadDeck } from '../rindle/appSsr'
+import { useDeckChatOpen } from '../rindle/deckPref'
 import { EditorStateProvider, useEditor } from '../editor/EditorState'
 import { parseEditorSearch } from '../editor/editorSearch'
 import { UndoProvider } from '../editor/UndoProvider'
@@ -115,7 +116,9 @@ function EditorInner({ deckId }: { deckId: string }) {
   // Contextual tools are editor-local overlays. The card column stays mounted behind them, preserving
   // scroll/caret state without introducing route or URL state.
   const [activeTool, setActiveTool] = useState<ActiveTool>(null)
-  const [chatOpen, setChatOpen] = useState(false)
+  // Persisted per-deck on this device (deck_pref local table): reopen a deck with the ✨ Chat panel the
+  // way you left it, instead of always closed.
+  const [chatOpen, setChatOpen] = useDeckChatOpen(deckId)
   const [styleIntent, setStyleIntent] = useState(0)
   const [controlsOpen, setControlsOpen] = useState(false)
   const topDockRef = useRef<HTMLDivElement>(null)


### PR DESCRIPTION
Add a deck_pref { local: true } table (deck_id -> chat_open) so reopening a deck restores whether the Chat panel was open, backed by persistLocal in the browser client. Flip chat_message to { local: "session" } so the advisor thread stays ephemeral now that local-table persistence is enabled.