### PR TITLE
Add deck, slide and image count caps to the entitlement seam

### DIFF
--- a/docs/COMMERCIAL_OVERLAY.md
+++ b/docs/COMMERCIAL_OVERLAY.md
@@ -27,8 +27,9 @@ here are **inert** until an overlay is supplied.
 
 - **Pro is pure feature-gating.** Decks live in one shared Rindle daemon DB scoped by `owner_id`; tier
   never changes where deck data lives. The Pro entitlement is a row in the **auth D1** (never Rindle →
-  never syncs to the browser), read on the server to allow private decks, remove the hosted image-storage
-  ceiling, and white-label shared decks. AI is BYOK on every plan.
+  never syncs to the browser), read on the server to allow private decks and to lift the hosted volume
+  ceilings (image bytes, image count, deck count, slides per deck). AI is BYOK on every plan, so
+  inference is not a tier axis — what Pro buys is privacy and headroom.
 
 ## The seam: `#commercial`
 
@@ -63,12 +64,26 @@ Two consumers in this repo import `#commercial`:
 
 All of these are no-ops under `COMMUNITY` (a clone/self-host), so nothing changes without an overlay:
 
-| Gate                     | Where                                                    | COMMUNITY behavior          |
-| ------------------------ | -------------------------------------------------------- | --------------------------- |
-| Private decks            | guarded deck writes in `server/rindle-api.ts`            | private decks allowed       |
-| Image storage            | `server/upload.ts` via `server/storage.ts`               | unlimited                   |
-| Shared-deck white label  | share SSR/view rendering                                 | Strut attribution shown     |
-| Pro badge / Upgrade link | `src/rindle/AccountControl.tsx` (seeded via `appSsr.ts`) | `upgradeUrl: null` → hidden |
+| Gate                     | Where                                                                     | COMMUNITY behavior          |
+| ------------------------ | ------------------------------------------------------------------------- | --------------------------- |
+| Private decks            | `createDeckGuarded` / `setDeckVisibilityGuarded` (`server/rindle-api.ts`) | private decks allowed       |
+| Image storage (bytes)    | `server/upload.ts` via `server/storage.ts`                                | unlimited                   |
+| Image count              | `server/upload.ts` via `server/storage.ts`                                | unlimited                   |
+| Deck count               | `createDeckGuarded` (`server/rindle-api.ts`)                              | unlimited                   |
+| Slides per deck          | `addSlideGuarded` (`server/rindle-api.ts`)                                | unlimited                   |
+| Shared-deck white label  | _declared only — `whiteLabelShare` is not read anywhere yet_              | Strut attribution shown     |
+| Pro badge / Upgrade link | `src/rindle/AccountControl.tsx` (seeded via `appSsr.ts`)                  | `upgradeUrl: null` → hidden |
+
+The two ceilings differ in kind, and an overlay should pick numbers accordingly:
+
+- **Meters** (`storageLimitBytes`, `imageLimit`) count against a monotonic per-user row in the auth D1.
+  R2 objects are content-addressed and never GC'd, so deleting an image does **not** give the slot back.
+- **Live counts** (`deckLimit`, `slidesPerDeckLimit`) are read from Rindle inside the mutation txn, so
+  deleting a deck or slide frees its slot immediately.
+
+`slidesPerDeckLimit` is the one to think twice about: it rejects mid-authoring, and the ✨ Generate /
+Narrate lanes append slides one mutation at a time, so a deck that crosses the cap lands partially
+generated. Prefer bounding deck **count**.
 
 ## Building an overlay
 

--- a/migrations-d1/0012_storage_image_count.sql
+++ b/migrations-d1/0012_storage_image_count.sql
@@ -1,0 +1,11 @@
+-- Cumulative per-user IMAGE COUNT, carried in the same storage_usage row as the byte total
+-- (0008_storage_usage.sql) because it has the identical lifecycle: one row per user, bumped on each
+-- stored image, monotonic (R2 objects are content-addressed / immutable and aren't garbage-collected on
+-- deck delete, so neither bytes nor count can go down). Backs the free tier's image cap
+-- (Entitlements.imageLimit; server/storage.ts) — the count companion to storageLimitBytes, bounding
+-- many-small-images abuse that a pure byte ceiling waves through. Untouched for self-host / Pro (both
+-- limits null → the write paths skip the D1 round-trip entirely). Existing rows default to 0, so accounts
+-- that uploaded before this migration start their count fresh; their bytes total is unaffected. Apply to
+-- prod with `wrangler d1 migrations apply strut-auth`; dev's local better-sqlite3 auth.db picks it up
+-- automatically (server/auth.ts migrateLocalAuth, which applies each file once).
+alter table storage_usage add column images integer not null default 0;

--- a/server/entitlements.ts
+++ b/server/entitlements.ts
@@ -36,5 +36,7 @@ export function entitlementSummary(ent: Entitlements): EntitlementSummary {
     isPro: ent.pro,
     upgradeUrl: commercial?.upgradeUrl ?? null,
     canKeepPrivate: ent.canKeepPrivate,
+    deckLimit: ent.deckLimit,
+    slidesPerDeckLimit: ent.slidesPerDeckLimit,
   }
 }

--- a/server/rindle-api.ts
+++ b/server/rindle-api.ts
@@ -200,14 +200,29 @@ const withShareOwner = <TArgs>(
   })
 
 // ---- entitlement-gated writes -------------------------------------------------------------------
-// Two writes carry a PLAN gate on top of the access gate — the pricing wedge: PUBLIC (link-shared) decks
-// are free & uncapped, keeping a deck PRIVATE is the paid feature. The entitlement lives in the auth D1
-// (getEntitlements), independent of the rindle txn; with no commercial overlay it's COMMUNITY
-// (canKeepPrivate=true), so both are no-ops for a clone (decks stay private by default, as before).
+// Three writes carry a PLAN gate on top of the access gate. The pricing wedge is privacy — PUBLIC
+// (link-shared) decks are free, keeping a deck PRIVATE is the paid feature — and the VOLUME caps
+// (deckLimit / slidesPerDeckLimit) bound how much a free account can pile into the hosted daemon. The
+// entitlement lives in the auth D1 (getEntitlements), independent of the rindle txn; with no commercial
+// overlay it's COMMUNITY (canKeepPrivate=true, every limit null), so all three are no-ops for a clone
+// (decks stay private by default and uncapped, exactly as before).
 
-/** createDeck: for an account that can't keep decks private (free tier), FORCE the new deck public and
- *  ensure a share token — even if a tampered client asked for 'private'. COMMUNITY/Pro (canKeepPrivate)
- *  pass straight through with the client's chosen visibility (default private). */
+/** Count rows matching a query INSIDE the open txn (read-your-writes). A root `count()` aggregate — one
+ *  `{ count }` row, `0` on empty input — so the gate costs a scalar read, not a row scan. */
+async function countRows(
+  tx: ServerMutationTx,
+  query: Parameters<ServerMutationTx['query']>[0],
+): Promise<number> {
+  const rows = (await tx.query(query)) as Array<{ count?: number }> | null
+  const n = Array.isArray(rows) ? rows[0]?.count : undefined
+  return typeof n === 'number' ? n : 0
+}
+
+/** createDeck: two plan gates. (1) For an account that can't keep decks private (free tier), FORCE the
+ *  new deck public and ensure a share token — even if a tampered client asked for 'private'. (2) Reject
+ *  once the principal already OWNS `deckLimit` decks. The count is a live read of the deck table, not a
+ *  meter, so deleting a deck frees its slot immediately. COMMUNITY/Pro pass straight through with the
+ *  client's chosen visibility (default private) and no cap. */
 const createDeckGuarded: ApiMutator<User, unknown> = async (tx, raw, ctx) => {
   const gen = sharedMutators.createDeck
   const a = gen.args.parse(raw)
@@ -216,6 +231,50 @@ const createDeckGuarded: ApiMutator<User, unknown> = async (tx, raw, ctx) => {
   if (!ent.canKeepPrivate) {
     a.visibility = 'public-read'
     if (!a.share_token) a.share_token = crypto.randomUUID()
+  }
+  if (ent.deckLimit != null) {
+    const owned = await countRows(tx, q.deck.where.owner_id(user).count())
+    if (owned >= ent.deckLimit) {
+      throw new RindleApiError(
+        'forbidden',
+        `Deck limit reached (${ent.deckLimit}). Delete a deck or upgrade to Pro for more.`,
+        403,
+      )
+    }
+  }
+  return runSharedMutation(gen, a, sharedCtx(ctx), tx)
+}
+
+/** addSlide: the normal editable-deck access gate PLUS the plan's per-deck slide cap. Counted live on
+ *  the TARGET deck (so it follows the deck, not the actor — an editor-collaborator adding to someone
+ *  else's deck is bounded by that deck, and deleting a slide frees a slot). Note this gate bites
+ *  MID-AUTHORING and the ✨ Generate / Narrate lanes append slides one mutation at a time, so a deck
+ *  that crosses the cap partway lands partially generated — see the caveat on
+ *  Entitlements.slidesPerDeckLimit before an overlay sets it non-null. */
+const addSlideGuarded: ApiMutator<User, unknown> = async (tx, raw, ctx) => {
+  const gen = sharedMutators.addSlide
+  const a = gen.args.parse(raw)
+  const user = requireUser(ctx.user)
+  const editable = await tx.query(
+    q.deck.where.id(a.deckId).where(deckEditableBy(user)).one(),
+  )
+  if (editable == null) {
+    throw new RindleApiError(
+      'forbidden',
+      'not permitted to edit this deck',
+      403,
+    )
+  }
+  const ent = await getEntitlements(user)
+  if (ent.slidesPerDeckLimit != null) {
+    const slides = await countRows(tx, q.slide.where.deck_id(a.deckId).count())
+    if (slides >= ent.slidesPerDeckLimit) {
+      throw new RindleApiError(
+        'forbidden',
+        `Slide limit reached (${ent.slidesPerDeckLimit} per deck). Upgrade to Pro for more.`,
+        403,
+      )
+    }
   }
   return runSharedMutation(gen, a, sharedCtx(ctx), tx)
 }
@@ -262,7 +321,7 @@ const apiMutators = defineApiMutators<User, ApiMutators<User>>({
   // is overridden below only to force free-tier decks public (it still writes owner_id = ctx.user).
   ...sharedApiMutators(sharedMutators, sharedCtx),
 
-  // ---- entitlement-gated: free-tier decks are forced public (see createDeckGuarded) ----
+  // ---- entitlement-gated: free-tier decks are forced public + volume-capped (see the guards above) ----
   createDeck: createDeckGuarded,
 
   // ---- deck edits: editable (owner or editor) ----
@@ -273,7 +332,7 @@ const apiMutators = defineApiMutators<User, ApiMutators<User>>({
     (a) => a.deckId,
     sharedMutators.mintCustomColor,
   ),
-  addSlide: withDeckEditable((a) => a.deckId, sharedMutators.addSlide),
+  addSlide: addSlideGuarded,
 
   // ---- deck admin: owner-only (+ publish entitlement on setDeckVisibility) ----
   setDeckVisibility: setDeckVisibilityGuarded,

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1,21 +1,30 @@
-// Durable per-user cumulative STORAGE counter (bytes) in the auth D1 — the ceiling for the free tier's
-// unlimited PUBLIC decks (Entitlements.storageLimitBytes). Enforced on image uploads (server/upload.ts).
-// Uses the auth D1 in production and better-sqlite3 locally; ONE row per user, monotonic — R2 objects are
-// content-addressed / immutable and
-// aren't GC'd on deck delete, so usage only grows. NOT touched for self-host / Pro (storageLimitBytes null
-// → the callers skip it entirely). Artifacts (small, deduped, count-capped) are excluded from accounting.
+// Durable per-user cumulative STORAGE counters in the auth D1 — total BYTES and total IMAGE COUNT, the
+// two ceilings for the free tier's unlimited PUBLIC decks (Entitlements.storageLimitBytes /
+// Entitlements.imageLimit). Enforced on image uploads (server/upload.ts). Uses the auth D1 in production
+// and better-sqlite3 locally; ONE row per user, monotonic — R2 objects are content-addressed / immutable
+// and aren't GC'd on deck delete, so usage only grows (removing an image from a slide does not free
+// quota). NOT touched for self-host / Pro (both limits null → the callers skip it entirely). Artifacts
+// (small, deduped, burst-throttled) are excluded from accounting.
 
 const TABLE = 'storage_usage'
 
-// user_id is the PK; `add` is an upsert-increment; `get` reads the running total (0 when absent).
+/** A user's running totals. `images` is 0 for rows written before 0012_storage_image_count.sql. */
+export interface StorageUsage {
+  bytes: number
+  images: number
+}
+
+// user_id is the PK; `add` is an upsert-increment on both counters; `get` reads the running totals
+// (zeroes when absent).
 const addSql =
-  `INSERT INTO ${TABLE} (user_id, bytes) VALUES (?, ?) ` +
-  'ON CONFLICT(user_id) DO UPDATE SET bytes = bytes + excluded.bytes'
-const getSql = `SELECT bytes FROM ${TABLE} WHERE user_id = ?`
+  `INSERT INTO ${TABLE} (user_id, bytes, images) VALUES (?, ?, ?) ` +
+  'ON CONFLICT(user_id) DO UPDATE SET bytes = bytes + excluded.bytes, ' +
+  'images = images + excluded.images'
+const getSql = `SELECT bytes, images FROM ${TABLE} WHERE user_id = ?`
 
 interface StorageStore {
-  add: (userId: string, bytes: number) => Promise<void>
-  get: (userId: string) => Promise<number>
+  add: (userId: string, bytes: number, images: number) => Promise<void>
+  get: (userId: string) => Promise<StorageUsage>
 }
 
 // Structural subsets (avoid pulling @cloudflare/workers-types / the native module into the build graph —
@@ -35,31 +44,33 @@ interface LocalDb {
   }
 }
 
+function num(v: unknown): number {
+  return typeof v === 'number' ? v : 0
+}
+
 function makeD1Store(db: D1Like): StorageStore {
   return {
-    add: async (userId, bytes) => {
-      await db.prepare(addSql).bind(userId, bytes).run()
+    add: async (userId, bytes, images) => {
+      await db.prepare(addSql).bind(userId, bytes, images).run()
     },
     get: async (userId) => {
       const row = await db
         .prepare(getSql)
         .bind(userId)
-        .first<{ bytes: number }>()
-      return row?.bytes ?? 0
+        .first<{ bytes: number; images: number }>()
+      return { bytes: num(row?.bytes), images: num(row?.images) }
     },
   }
 }
 
 function makeSqliteStore(db: LocalDb): StorageStore {
   return {
-    add: async (userId, bytes) => {
-      db.prepare(addSql).run(userId, bytes)
+    add: async (userId, bytes, images) => {
+      db.prepare(addSql).run(userId, bytes, images)
     },
     get: async (userId) => {
-      const row = db.prepare(getSql).get(userId) as
-        | { bytes?: number }
-        | undefined
-      return typeof row?.bytes === 'number' ? row.bytes : 0
+      const row = db.prepare(getSql).get(userId)
+      return { bytes: num(row?.bytes), images: num(row?.images) }
     },
   }
 }
@@ -102,31 +113,47 @@ async function loadLocalSqlite(): Promise<LocalDb> {
 
 // ---- public API ----
 
-/** Would storing `addBytes` more keep the user within `limit`? Returns the check plus the current total.
- *  A coarse pre-check — concurrent writes can race slightly past the cap, bounded by the per-file max. */
+/** The plan's storage ceilings; null on either axis = unlimited on that axis. */
+export interface StorageLimits {
+  bytes: number | null
+  images: number | null
+}
+
+/** Which ceiling a rejected upload hit, so the caller can word the error. */
+export type StorageDenial = 'bytes' | 'images'
+
+/** Would storing ONE more image of `addBytes` keep the user inside both ceilings? Returns the verdict
+ *  (plus which axis blocked it) and the current totals. A coarse pre-check — concurrent uploads can race
+ *  slightly past a cap, bounded by the per-file max on bytes and by the in-flight count on images. */
 export async function checkStorage(
   userId: string,
   addBytes: number,
-  limit: number,
+  limits: StorageLimits,
   store?: StorageStore,
-): Promise<{ allowed: boolean; used: number }> {
+): Promise<{ allowed: boolean; denied?: StorageDenial; used: StorageUsage }> {
   const used = await (store ?? (await getStore())).get(userId)
-  return { allowed: used + addBytes <= limit, used }
+  if (limits.bytes != null && used.bytes + addBytes > limits.bytes)
+    return { allowed: false, denied: 'bytes', used }
+  if (limits.images != null && used.images + 1 > limits.images)
+    return { allowed: false, denied: 'images', used }
+  return { allowed: true, used }
 }
 
-/** Record `bytes` of newly-stored data against the user's running total (call AFTER a successful write). */
+/** Record `bytes` and `images` of newly-stored data against the user's running totals (call AFTER a
+ *  successful write). Both counters are monotonic — see the header. */
 export async function recordStorage(
   userId: string,
   bytes: number,
+  images: number,
   store?: StorageStore,
 ): Promise<void> {
-  await (store ?? (await getStore())).add(userId, bytes)
+  await (store ?? (await getStore())).add(userId, bytes, images)
 }
 
-/** The user's current stored bytes. */
+/** The user's current stored bytes + image count. */
 export async function getStorageUsed(
   userId: string,
   store?: StorageStore,
-): Promise<number> {
+): Promise<StorageUsage> {
   return (store ?? (await getStore())).get(userId)
 }

--- a/server/upload.ts
+++ b/server/upload.ts
@@ -207,16 +207,24 @@ export async function uploadFromRequest(
     if (body.byteLength > MAX_BYTES)
       throw new UploadError('image must be under 10 MB', 413)
 
-    // Per-plan storage ceiling (free tier). null (self-host / Pro) skips this with no D1 touch. Pre-check
-    // before storing; record after a successful put (R2 objects aren't GC'd → the counter is monotonic).
+    // Per-plan storage ceilings (free tier): total BYTES and total IMAGE COUNT. Both null (self-host /
+    // Pro) skips this with no D1 touch. Pre-check before storing; record after a successful put (R2
+    // objects aren't GC'd → both counters are monotonic).
     const { getEntitlements } = await import('./entitlements.ts')
-    const limit = (await getEntitlements(user)).storageLimitBytes
-    if (limit != null) {
+    const ent = await getEntitlements(user)
+    const limits = {
+      bytes: ent.storageLimitBytes,
+      images: ent.imageLimit,
+    }
+    const metered = limits.bytes != null || limits.images != null
+    if (metered) {
       const { checkStorage } = await import('./storage.ts')
-      const { allowed } = await checkStorage(user, body.byteLength, limit)
-      if (!allowed)
+      const { denied } = await checkStorage(user, body.byteLength, limits)
+      if (denied)
         throw new UploadError(
-          'Storage limit reached — upgrade to Pro for more storage.',
+          denied === 'images'
+            ? 'Image limit reached — upgrade to Pro for more images.'
+            : 'Storage limit reached — upgrade to Pro for more storage.',
           413,
         )
     }
@@ -230,9 +238,9 @@ export async function uploadFromRequest(
         ? await putS3(cfg, key, body, contentType)
         : await putLocal(key, body)
 
-    if (limit != null) {
+    if (metered) {
       const { recordStorage } = await import('./storage.ts')
-      await recordStorage(user, body.byteLength).catch(() => {})
+      await recordStorage(user, body.byteLength, 1).catch(() => {})
     }
     return Response.json({ url })
   } catch (err) {

--- a/shared/commercial.ts
+++ b/shared/commercial.ts
@@ -18,16 +18,33 @@ export interface Entitlements {
    *  the R2 upload path via server/storage.ts's per-user counter. Artifacts are excluded: they are small,
    *  content-addressed, and protected by a light burst throttle. */
   storageLimitBytes: number | null
+  /** Max IMAGES the account may upload, cumulative; null = unlimited. The companion count cap to
+   *  storageLimitBytes — bytes bound what we pay R2, this bounds many-small-images abuse the byte
+   *  ceiling waves through. Monotonic for the same reason bytes are (R2 objects are content-addressed
+   *  and not GC'd on deck delete), so removing an image does NOT free a slot. */
+  imageLimit: number | null
+  /** Max DECKS the account may own; null = unlimited. Enforced at createDeck (server/rindle-api.ts) by
+   *  counting the principal's decks inside the mutation txn — a LIVE count, not a meter, so deleting a
+   *  deck frees its slot immediately. */
+  deckLimit: number | null
+  /** Max SLIDES in ONE deck; null = unlimited. Enforced at addSlide, counted live per deck like
+   *  deckLimit. Note this one bites mid-flight (the user is already authoring when they hit it) and it
+   *  bounds the ✨ Generate / Narrate lanes, which append many slides at once — prefer leaving it null
+   *  and capping deck COUNT unless there is a concrete cost to defend. */
+  slidesPerDeckLimit: number | null
   /** Drop the PoweredBy / "shared read-only" watermark on shared decks (Pro white-label). */
   whiteLabelShare: boolean
 }
 
-/** The no-overlay default — private decks allowed and no hosted-storage cap. AI remains BYOK, as it is on
- *  every hosted plan. Self-hosters get the full app with zero billing setup. */
+/** The no-overlay default — private decks allowed and no hosted-storage, image, deck or slide cap. AI
+ *  remains BYOK, as it is on every hosted plan. Self-hosters get the full app with zero billing setup. */
 export const COMMUNITY: Entitlements = {
   pro: false,
   canKeepPrivate: true,
   storageLimitBytes: null,
+  imageLimit: null,
+  deckLimit: null,
+  slidesPerDeckLimit: null,
   whiteLabelShare: false,
 }
 
@@ -38,6 +55,12 @@ export interface EntitlementSummary {
   upgradeUrl: string | null
   /** false → the client creates new decks public and hides the "make private" control (a free viewer). */
   canKeepPrivate: boolean
+  /** Seeded so the UI can DISABLE "New deck" / "Add slide" at the cap instead of letting the write fly
+   *  and snap back — frictionless means not offering what the server will reject. The server stays
+   *  authoritative; these are presentation-only. null = unlimited (the open-source default → no cap UI).
+   *  Only the counts the client can actually observe are seeded; the image cap is upload-time only. */
+  deckLimit: number | null
+  slidesPerDeckLimit: number | null
 }
 
 /** The overlay module contract: `#commercial` exports `commercial: Commercial | null`. */

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -51,6 +51,16 @@ function Dashboard() {
   // (self-host / Pro) creates private. The server (rindle-api createDeckGuarded) is authoritative — this
   // just keeps the optimistic row in sync so it doesn't snap on confirm.
   const makesPublic = entitlement?.canKeepPrivate === false
+
+  // Plan deck cap (null / no overlay → uncapped). Shown, and used to disable create/import, so the user
+  // never fires a write the server will reject and watch it snap back. NOTE the dashboard reads at most
+  // DECKS_LIMIT decks, so a cap ABOVE that can't be observed here — the server stays authoritative and
+  // simply rejects with its own message.
+  const deckLimit = entitlement?.deckLimit ?? null
+  const atDeckLimit = deckLimit != null && decks.length >= deckLimit
+  const deckLimitHint = atDeckLimit
+    ? `You've used all ${deckLimit} decks on your plan — delete one to make room.`
+    : undefined
   function newDeckVisibility(): {
     visibility: 'private' | 'public-read'
     share_token: string
@@ -113,8 +123,9 @@ function Dashboard() {
         <div>
           <h1 className="dash__title">Your decks</h1>
           <p className="dash__sub">
-            {decks.length} presentation{decks.length === 1 ? '' : 's'},
-            local-first on Rindle.
+            {decks.length}
+            {deckLimit != null ? ` of ${deckLimit}` : ''} presentation
+            {decks.length === 1 ? '' : 's'}, local-first on Rindle.
           </p>
         </div>
         <div className="dash__actions">
@@ -128,13 +139,16 @@ function Dashboard() {
           <button
             className="btn"
             onClick={() => fileRef.current?.click()}
-            title="Import a .strut file"
+            disabled={atDeckLimit}
+            title={deckLimitHint ?? 'Import a .strut file'}
           >
             <Upload size={16} /> Import
           </button>
           <button
             className="btn btn--primary"
             onClick={() => setCreating(true)}
+            disabled={atDeckLimit}
+            title={deckLimitHint}
           >
             <Plus size={16} /> New deck
           </button>


### PR DESCRIPTION
The paid tier had thinned out: after the move to BYOK-only AI there was no
inference meter left, so Pro amounted to private decks plus a storage-byte
ceiling (whiteLabelShare is declared but never read). Bytes alone don't bound
what a free account can pile into the hosted daemon — thousands of small
images, or unbounded decks and slides, all pass.

Extend Entitlements with three nullable volume caps, enforced server-side and
null under COMMUNITY so a clone/self-host is unchanged:

- imageLimit — cumulative image COUNT, carried in the storage_usage row next to
  bytes (new migration adds the column). Monotonic for the same reason bytes
  are: R2 objects are content-addressed and not GC'd on delete.
- deckLimit — checked in createDeckGuarded via a root count() inside the
  mutation txn, so deleting a deck frees its slot immediately.
- slidesPerDeckLimit — same live count, in a new addSlideGuarded that keeps the
  existing editable-deck access gate. Left null by default and documented as
  the one to think twice about: it rejects mid-authoring and the Generate /
  Narrate lanes append slides one mutation at a time.

deckLimit and slidesPerDeckLimit are seeded into EntitlementSummary so the UI
can disable an action rather than let the write fly and snap back; the
dashboard now shows "n of N presentations" and disables New deck / Import at
the cap. The numbers themselves stay in the private overlay's plans.ts.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PT5EJqSjkDTCKNArG1dEwh